### PR TITLE
複数のheredocに対応したい

### DIFF
--- a/executor/exec_fank.c
+++ b/executor/exec_fank.c
@@ -6,7 +6,7 @@
 /*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/21 14:24:41 by shattori          #+#    #+#             */
-/*   Updated: 2025/06/30 19:07:32 by nando            ###   ########.fr       */
+/*   Updated: 2025/06/30 22:08:40 by nando            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,8 @@ static void	handle_redirections(t_list *redir_list, t_shell *shell)
 	t_redirection	*redir;
 	int				fd;
 
+	// char			*last_tmpfile;
+	// last_tmpfile = process_heredoc(redir_list, shell);
 	while (redir_list)
 	{
 		redir = redir_list->content;
@@ -28,10 +30,8 @@ static void	handle_redirections(t_list *redir_list, t_shell *shell)
 		else if (redir->type == REDIR_APPEND)
 			fd = open(redir->filename, O_WRONLY | O_CREAT | O_APPEND, 0644);
 		else if (redir->type == REDIR_HEREDOC)
-		{
-			fd = open(run_heredoc(redir->filename, redir->need_expand, shell),
-					O_RDONLY);
-		}
+			// fd = open(last_tmpfile, O_RDONLY);
+			fd = open(process_heredoc(redir_list, shell), O_RDONLY);//↑のコメントアウト外すときは、この行はコメントアウトしてほしいです。
 		if (fd < 0)
 		{
 			perror("redirection");

--- a/heredoc/heredoc.c
+++ b/heredoc/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/24 22:34:59 by nando             #+#    #+#             */
-/*   Updated: 2025/06/30 19:00:05 by nando            ###   ########.fr       */
+/*   Updated: 2025/06/30 21:52:51 by nando            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -87,27 +87,34 @@ char	*run_heredoc(const char *delimiter, bool need_expand, t_shell *shell)
 	return (path);
 }
 
-// void	process_heredoc(t_command *cmd, t_env *env)
-// {
-// 	t_list			*node;
-// 	t_redirection	*redir;
-// 	char			*tmpfile;
+char	*process_heredoc(t_list *redir_list, t_shell *shell)
+{
+	t_redirection	*redir;
+	char			*tmpfile;
+	bool			flag;
 
-// 	if (!cmd || !cmd->redirections)
-// 		return ;
-// 	node = cmd->redirections;
-// 	while (node)
-// 	{
-// 		redir = (t_redirection *)node->content;
-// 		if (redir->type == REDIR_HEREDOC)
-// 		{
-// 			tmpfile = run_heredoc(redir->filename, redir->need_expand, env);
-// 			free(redir->filename);
-// 			redir->filename = tmpfile;
-// 		}
-// 		node = node->next;
-// 	}
-// }
+	if (!redir_list)
+		return (NULL);
+	tmpfile = NULL;
+	flag = false;
+	while (redir_list)
+	{
+		redir = (t_redirection *)redir_list->content;
+		if (redir->type == REDIR_HEREDOC)
+		{
+			if (flag)
+				unlink(tmpfile);
+			tmpfile = run_heredoc(redir->filename, redir->need_expand, shell);
+			if (!tmpfile)
+				return (NULL);
+			free(redir->filename);
+			redir->filename = tmpfile;
+			flag = true;
+		}
+		redir_list = redir_list->next;
+	}
+	return (redir->filename);
+}
 
 // void	handle_heredoc(t_andor *node, t_env *env)
 // {

--- a/heredoc/heredoc.h
+++ b/heredoc/heredoc.h
@@ -6,7 +6,7 @@
 /*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/19 12:54:02 by nando             #+#    #+#             */
-/*   Updated: 2025/06/30 19:11:39 by nando            ###   ########.fr       */
+/*   Updated: 2025/06/30 21:52:39 by nando            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,5 +17,6 @@
 # include <stdbool.h>
 
 char	*run_heredoc(const char *delimiter, bool need_expand, t_shell *shell);
+char	*process_heredoc(t_list *redir_list, t_shell *shell);
 
 #endif


### PR DESCRIPTION
この内容で実行してみてほしいです。
おそらくbashライクな挙動にはなっているはず。

ただ、　executorのhandle_redir関数にも一部修正を加えることを前提としているので、
handle_redir関数がこれだとまずいということがあればまた考えます。

テストしたコマンド
cat << EOF << END ２重
cat << EOF << END << AND　３重
cat << EOF << END > out　２重×アウトプット
cat << EOF << END > out << AND　３重×アウトプット（後ろにheredoc）
です。

もしhandle_redir関数的に問題なさそうであれば、マージしていただけると！
ダメそうだったら、一旦コメントかdiscodeに話してほしいっす！