### PR TITLE
heredoc実行時のクオート有無判定フラグの動作確認

### DIFF
--- a/expander/expander.c
+++ b/expander/expander.c
@@ -6,7 +6,7 @@
 /*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/08 14:30:21 by nando             #+#    #+#             */
-/*   Updated: 2025/07/01 20:03:06 by nando            ###   ########.fr       */
+/*   Updated: 2025/07/02 16:28:58 by nando            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,6 +21,7 @@ char	*expand_string(char *arg, t_shell *shell, t_expand *ctx, t_list *node)
 	t_redirection	*redir;
 
 	redir = (t_redirection *)node->content;
+	redir->need_expand = false;
 	if (arg[0] == '\'')
 	{
 		cleaned_quote = remove_quote(redir->need_expand, arg);
@@ -32,7 +33,6 @@ char	*expand_string(char *arg, t_shell *shell, t_expand *ctx, t_list *node)
 		cleaned_quote = expand_variables(cleaned_quote, shell);
 		return (cleaned_quote);
 	}
-	redir->need_expand = false;
 	after = expand_all_type(arg, shell, ctx);
 	return (after);
 }

--- a/heredoc/heredoc.c
+++ b/heredoc/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/24 22:34:59 by nando             #+#    #+#             */
-/*   Updated: 2025/06/30 21:52:51 by nando            ###   ########.fr       */
+/*   Updated: 2025/07/03 17:16:17 by nando            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -100,6 +100,8 @@ char	*process_heredoc(t_list *redir_list, t_shell *shell)
 	while (redir_list)
 	{
 		redir = (t_redirection *)redir_list->content;
+		printf("redir->need_expand = %s\n",
+			redir->need_expand ? "true" : "false");
 		if (redir->type == REDIR_HEREDOC)
 		{
 			if (flag)
@@ -115,99 +117,3 @@ char	*process_heredoc(t_list *redir_list, t_shell *shell)
 	}
 	return (redir->filename);
 }
-
-// void	handle_heredoc(t_andor *node, t_env *env)
-// {
-// 	t_list		*cmds;
-// 	t_command	*cmd;
-
-// 	if (!node)
-// 		return ;
-// 	if (node->type == ANDOR_PIPELINE)
-// 	{
-// 		cmds = node->pipeline->commands;
-// 		while (cmds)
-// 		{
-// 			cmd = (t_command *)cmds->content;
-// 			process_heredoc(cmd, env);
-// 			cmds = cmds->next;
-// 		}
-// 	}
-// 	else
-// 	{
-// 		handle_heredoc(node->left, env);
-// 		handle_heredoc(node->right, env);
-// 	}
-// }
-
-// #include <fcntl.h>
-// #include <readline/readline.h>
-// #include <stdio.h>
-// #include <stdlib.h>
-// #include <string.h>
-// #include <unistd.h>
-
-// int	main(int argc, char **argv, char **envp)
-// {
-// 	char	*path;
-// 	int		fd;
-// 	char	buf[1024];
-// 	ssize_t	n;
-// 	t_env	*env;
-
-// 	env = malloc(sizeof(t_env));
-// 	env = init_env(envp);
-// 	// ■ テスト１: need_expand = false
-// 	printf("=== heredoc without expansion (delimiter: END) ===\n");
-// 	path = run_heredoc("END", false, env);
-// 	if (!path)
-// 	{
-// 		fprintf(stderr, "run_heredoc failed\n");
-// 		return (1);
-// 	}
-// 	printf("→ saved to %s\n", path);
-// 	fd = open(path, O_RDONLY);
-// 	if (fd < 0)
-// 	{
-// 		perror("open");
-// 		free(path);
-// 		return (1);
-// 	}
-// 	printf("--- file content ---\n");
-// 	while ((n = read(fd, buf, sizeof(buf) - 1)) > 0)
-// 	{
-// 		buf[n] = '\0';
-// 		printf("%s", buf);
-// 	}
-// 	printf("--- end content ---\n");
-// 	close(fd);
-// 	unlink(path);
-// 	free(path);
-// 	// ■ テスト２: need_expand = true
-// 	printf("\n=== heredoc with expansion (delimiter: EXP) ===\n");
-// 	path = run_heredoc("EXP", true, env);
-// 	if (!path)
-// 	{
-// 		fprintf(stderr, "run_heredoc failed\n");
-// 		return (1);
-// 	}
-// 	printf("→ saved to %s\n", path);
-// 	fd = open(path, O_RDONLY);
-// 	if (fd < 0)
-// 	{
-// 		perror("open");
-// 		free(path);
-// 		return (1);
-// 	}
-// 	printf("--- file content ---\n");
-// 	while ((n = read(fd, buf, sizeof(buf) - 1)) > 0)
-// 	{
-// 		buf[n] = '\0';
-// 		printf("%s", buf);
-// 	}
-// 	printf("--- end content ---\n");
-// 	close(fd);
-// 	unlink(path);
-// 	free(path);
-// 	return (0);
-// }

--- a/lexer/utils.c
+++ b/lexer/utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   utils.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: shattori <shattori@student.42.fr>          +#+  +:+       +#+        */
+/*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/29 17:18:47 by nando             #+#    #+#             */
-/*   Updated: 2025/06/29 16:35:56 by shattori         ###   ########.fr       */
+/*   Updated: 2025/07/02 15:15:47 by nando            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,6 @@
 
 void	quate_error(t_lexer *ctx)
 {
-
 	ft_printf("quate not closed.\n");
 	free_buf(&ctx->buf);
 	free_tokens(ctx->head);

--- a/linearizer/linearizer.h
+++ b/linearizer/linearizer.h
@@ -6,7 +6,7 @@
 /*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/15 16:14:13 by shattori          #+#    #+#             */
-/*   Updated: 2025/06/30 18:48:46 by nando            ###   ########.fr       */
+/*   Updated: 2025/07/02 16:43:24 by nando            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,7 +32,7 @@ typedef struct s_redirection
 {
 	t_redir_type			type;
 	char					*filename;
-	int						need_expand;
+	bool					need_expand;
 }							t_redirection;
 
 typedef struct s_command

--- a/signal/signal.c
+++ b/signal/signal.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   signal.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: shattori <shattori@student.42.fr>          +#+  +:+       +#+        */
+/*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/15 14:59:39 by nando             #+#    #+#             */
-/*   Updated: 2025/06/29 16:36:15 by shattori         ###   ########.fr       */
+/*   Updated: 2025/07/02 15:24:39 by nando            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,25 +36,3 @@ void	init_signal(void)
 	sigaction(SIGINT, &sa, NULL);
 	signal(SIGQUIT, SIG_IGN);
 }
-
-// static void	prompt(void)
-// {
-// 	char	*cmd;
-
-// 	cmd = readline("minishell$ ");
-// 	if (!cmd)
-// 	{
-// 		ft_printf("exit\n");
-// 		exit(0);
-// 	}
-// 	add_history(cmd);
-// 	free(cmd);
-// }
-
-// int	main(void)
-// {
-// 	init_signal();
-// 	while (1)
-// 		prompt();
-// 	exit(0);
-// }


### PR DESCRIPTION
１．heredoc実行時
delimiterのクオート有無の判定のためのフラグの動作確認してました。
上手く動作していなかったので、校舎で確認したく、一旦マージしたいです。
（’cat << "EOF"’　’cat << EOF’  で挙動が変わる実装）

２．redirections構造体の中身の型変更（int　⇒　bool）