### PR TITLE
fix/parent

### DIFF
--- a/builtin/exit.c
+++ b/builtin/exit.c
@@ -6,7 +6,7 @@
 /*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/05 15:28:33 by nando             #+#    #+#             */
-/*   Updated: 2025/06/26 20:57:57 by nando            ###   ########.fr       */
+/*   Updated: 2025/07/04 20:11:53 by nando            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,11 +15,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-
-typedef struct s_exit
-{
-	int		exit_status;
-}			t_exit;
 
 static int	is_numeric(const char *str)
 {
@@ -37,70 +32,28 @@ static int	is_numeric(const char *str)
 	return (1);
 }
 
-static void	handle_not_numeric(int exit_status, char *arg)
-{
-	printf("minishell: exit: %s: numeric argument required\n", arg);
-	exit_status = 255;
-	exit(exit_status);
-}
-
-static void	handle_exit_argument(t_exit *exit_s, char *arg)
-{
-	if (!is_numeric(arg))
-		handle_not_numeric(exit_s->exit_status, arg);
-	exit_s->exit_status = ft_atoi(arg);
-	exit_s->exit_status = exit_s->exit_status % 256;
-	if (exit_s->exit_status < 0)
-		exit_s->exit_status += 256;
-	exit(exit_s->exit_status);
-}
-
 int	builtin_exit(char **args)
 {
-	t_exit	*exit_s;
-	int		count;
+	int	status;
+	int	count;
 
-	exit_s = malloc(sizeof(t_exit));
 	count = count_args(args);
 	printf("exit\n");
 	if (count > 2)
-		return (NG);
+	{
+		fprintf(stderr, "minishell: exit: too many arguments\n");
+		return (1);
+	}
 	else if (count == 1)
 		exit(0);
-	else if (count == 2)
-		handle_exit_argument(exit_s, args[1]);
-	return (OK);
+	if (!is_numeric(args[1]))
+	{
+		fprintf(stderr, "minishell: exit: %s: numeric argument required\n",
+			args[1]);
+		exit(255);
+	}
+	status = ft_atoi(args[1]) % 256;
+	if (status < 0)
+		status += 256;
+	exit(status);
 }
-
-// この関数はテスト時に呼び出されるため、exit()の呼び出しで
-// 実際にはプロセスが終了するので、1テストずつ手動実行 or bashで逐次実行が推奨です。
-
-// int	main(void)
-// {
-// 	// 1️⃣ 引数なし（正常終了）
-// 	char *args1[] = {"exit", NULL};
-// 	printf("\n===== Test 1: exit with no argument =====\n");
-// 	builtin_exit(args1);
-
-// 	// 2️⃣ 数値引数あり（正常終了）
-// 	char *args2[] = {"exit", "42", NULL};
-// 	printf("\n===== Test 2: exit with valid numeric argument =====\n");
-// 	builtin_exit(args2);
-
-// 	// 3️⃣ 数値引数あり（負数）
-// 	char *args3[] = {"exit", "-5", NULL};
-// 	printf("\n===== Test 3: exit with negative numeric argument =====\n");
-// 	builtin_exit(args3);
-
-// 	// 4️⃣ 数値引数が非数字（エラー終了）
-// 	char *args4[] = {"exit", "abc", NULL};
-// 	printf("\n===== Test 4: exit with non-numeric argument =====\n");
-// 	builtin_exit(args4);
-
-// 	// 5️⃣ 引数が多すぎる（too many arguments）
-// 	char *args5[] = {"exit", "1", "extra", NULL};
-// 	printf("\n===== Test 5: exit with too many arguments =====\n");
-// 	builtin_exit(args5);
-
-// 	return (0);
-// }

--- a/executor/exec_fank.c
+++ b/executor/exec_fank.c
@@ -6,7 +6,7 @@
 /*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/21 14:24:41 by shattori          #+#    #+#             */
-/*   Updated: 2025/07/04 19:24:26 by nando            ###   ########.fr       */
+/*   Updated: 2025/07/04 20:27:27 by nando            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -260,7 +260,8 @@ static int	exec_pipeline(t_pipeline *pipeline, t_shell *shell)
 			return (exec_subshell(cmd, shell));
 		if (is_builtin(cmd->argv[0]))
 		{
-			handle_redirections(cmd->redirections);
+			//handle_redirections(cmd->redirections);
+			handle_redirections(cmd);
 			shell->exit_status = exec_builtin(cmd->argv, shell->env);
 			return (shell->exit_status);
 		}
@@ -286,7 +287,8 @@ static int	exec_pipeline(t_pipeline *pipeline, t_shell *shell)
 				close(pipefd[0]);
 				close(pipefd[1]);
 			}
-			handle_redirections(cmd->redirections);
+			//handle_redirections(cmd->redirections);
+			handle_redirections(cmd);
 			if (cmd->subshell_ast)
 			{
 				exit(exec_subshell(cmd, shell));

--- a/executor/exec_fank.c
+++ b/executor/exec_fank.c
@@ -3,25 +3,61 @@
 /*                                                        :::      ::::::::   */
 /*   exec_fank.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: shattori <shattori@student.42.fr>          +#+  +:+       +#+        */
+/*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/21 14:24:41 by shattori          #+#    #+#             */
-/*   Updated: 2025/07/04 17:05:28 by shattori         ###   ########.fr       */
+/*   Updated: 2025/07/04 19:24:26 by nando            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "executor.h"
 
-static void	handle_redirections(t_list *redir_list)
+// static void	handle_redirections(t_list *redir_list)
+//{
+//	t_redirection	*redir;
+//	int				fd;
+//	char			*last_tmpfile;
+
+//	while (redir_list)
+//	{
+//		redir = redir_list->content;
+//		printf("redir->filename = %s\n", redir->filename);
+//		last_tmpfile = redir->filename;
+//		fd = -1;
+//		if (redir->type == REDIR_IN)
+//			fd = open(redir->filename, O_RDONLY);
+//		else if (redir->type == REDIR_OUT)
+//			fd = open(redir->filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+//		else if (redir->type == REDIR_APPEND)
+//			fd = open(redir->filename, O_WRONLY | O_CREAT | O_APPEND, 0644);
+//		else if (redir->type == REDIR_HEREDOC)
+//			fd = open(last_tmpfile, O_RDONLY);
+//		if (fd < 0)
+//		{
+//			perror("redirection");
+//			exit(1);
+//		}
+//		if (redir->type == REDIR_IN || redir->type == REDIR_HEREDOC)
+//			dup2(fd, STDIN_FILENO);
+//		else
+//			dup2(fd, STDOUT_FILENO);
+//		close(fd);
+//		redir_list = redir_list->next;
+//	}
+//}
+
+static void	handle_redirections(t_command *cmd)
 {
+	t_list			*redir_list;
 	t_redirection	*redir;
 	int				fd;
 	char			*last_tmpfile;
 
+	redir_list = cmd->redirections;
 	while (redir_list)
 	{
 		redir = redir_list->content;
-		last_tmpfile = redir->filename;
+		last_tmpfile = cmd->heredoc_filename;
 		fd = -1;
 		if (redir->type == REDIR_IN)
 			fd = open(redir->filename, O_RDONLY);
@@ -193,7 +229,8 @@ int	exec_simple_command(t_command *cmd, t_shell *shell)
 		return (perror("fork"), 1);
 	if (pid == 0)
 	{
-		handle_redirections(cmd->redirections);
+		// handle_redirections(cmd->redirections);
+		handle_redirections(cmd);
 		envp = convert_env(shell->env);
 		path = search_path(cmd->argv[0], shell->env);
 		if (!path)
@@ -220,7 +257,7 @@ static int	exec_pipeline(t_pipeline *pipeline, t_shell *shell)
 	{
 		cmd = cmd_list->content;
 		if (cmd->subshell_ast)
-			return(exec_subshell(cmd, shell));
+			return (exec_subshell(cmd, shell));
 		if (is_builtin(cmd->argv[0]))
 		{
 			handle_redirections(cmd->redirections);

--- a/expander/expander.c
+++ b/expander/expander.c
@@ -6,7 +6,7 @@
 /*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/08 14:30:21 by nando             #+#    #+#             */
-/*   Updated: 2025/07/02 16:28:58 by nando            ###   ########.fr       */
+/*   Updated: 2025/07/04 18:52:32 by nando            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,15 +21,14 @@ char	*expand_string(char *arg, t_shell *shell, t_expand *ctx, t_list *node)
 	t_redirection	*redir;
 
 	redir = (t_redirection *)node->content;
-	redir->need_expand = false;
 	if (arg[0] == '\'')
 	{
-		cleaned_quote = remove_quote(redir->need_expand, arg);
+		cleaned_quote = remove_quote(arg);
 		return (cleaned_quote);
 	}
 	else if (arg[0] == '\"')
 	{
-		cleaned_quote = remove_quote(redir->need_expand, arg);
+		cleaned_quote = remove_quote(arg);
 		cleaned_quote = expand_variables(cleaned_quote, shell);
 		return (cleaned_quote);
 	}

--- a/expander/expander.h
+++ b/expander/expander.h
@@ -6,7 +6,7 @@
 /*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/26 20:20:02 by nando             #+#    #+#             */
-/*   Updated: 2025/06/30 18:58:29 by nando            ###   ########.fr       */
+/*   Updated: 2025/07/04 18:52:54 by nando            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -74,7 +74,7 @@ char						*make_new_arg(char *arg, t_var *var);
 char						*expand_variables(char *arg, t_shell *shell);
 char						*expand_tilda(char *arg, t_env *env);
 
-char						*remove_quote(bool need_expand, char *arg);
+char						*remove_quote(char *arg);
 char						*expand_all_type(char *arg, t_shell *shell,
 								t_expand *ctx);
 void						expander(t_andor *ast, t_shell *shell);

--- a/expander/utils2.c
+++ b/expander/utils2.c
@@ -6,18 +6,17 @@
 /*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/26 17:12:10 by nando             #+#    #+#             */
-/*   Updated: 2025/07/01 20:00:34 by nando            ###   ########.fr       */
+/*   Updated: 2025/07/04 18:52:48 by nando            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "expander.h"
 
-char	*remove_quote(bool need_expand, char *arg)
+char	*remove_quote(char *arg)
 {
 	size_t	strlen;
 	char	*result;
 
-	need_expand = true;
 	strlen = ft_strlen(arg);
 	if (strlen < 2)
 		return (ft_strdup(arg));

--- a/expander/variables.c
+++ b/expander/variables.c
@@ -6,7 +6,7 @@
 /*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/13 15:40:45 by nando             #+#    #+#             */
-/*   Updated: 2025/06/30 18:17:15 by nando            ###   ########.fr       */
+/*   Updated: 2025/07/04 20:19:49 by nando            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,6 +53,7 @@ void	search_env_value(t_var *var, t_shell *shell)
 	var->value = NULL;
 	if (strcmp(var->key, "?") == 0)
 	{
+		printf("shell->exit_status = %d\n", shell->exit_status);
 		var->value = ft_itoa(shell->exit_status);
 		return ;
 	}

--- a/heredoc/heredoc.h
+++ b/heredoc/heredoc.h
@@ -6,7 +6,7 @@
 /*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/19 12:54:02 by nando             #+#    #+#             */
-/*   Updated: 2025/07/03 23:26:04 by nando            ###   ########.fr       */
+/*   Updated: 2025/07/04 18:55:15 by nando            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,8 +18,7 @@
 
 typedef struct s_command	t_command;
 
-char						*run_heredoc(const char *delimiter,
-								bool need_expand, t_shell *shell);
+char						*run_heredoc(char *delimiter, t_shell *shell);
 void						process_heredoc(t_command *cmd, t_shell *shell);
 
 #endif

--- a/lexer/lexer.c
+++ b/lexer/lexer.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   lexer.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: shattori <shattori@student.42.fr>          +#+  +:+       +#+        */
+/*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/15 20:23:45 by nando             #+#    #+#             */
-/*   Updated: 2025/06/22 18:47:53 by shattori         ###   ########.fr       */
+/*   Updated: 2025/07/04 20:40:52 by nando            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,6 +52,8 @@ int	init_lexer(t_lexer *ctx, char *input)
 	ctx->prev_state = STA_DEFAULT;
 	ctx->posi = 0;
 	ctx->assignment_flag = 0;
+	ctx->left_p_count = 0;
+	ctx->right_p_count = 0;
 	ctx->head = create_token(TOK_NUL, NULL);
 	if (!ctx->head)
 		return (ERROR);
@@ -105,6 +107,11 @@ t_token	*lexer(char *input)
 	if (ctx.state == STA_IN_SQUOTE || ctx.state == STA_IN_DQUOTE)
 	{
 		quate_error(&ctx);
+		return (NULL);
+	}
+	if (ctx.left_p_count != ctx.right_p_count)
+	{
+		parent_error(&ctx);
 		return (NULL);
 	}
 	token_head = finish_lexing(&ctx);

--- a/lexer/lexer.h
+++ b/lexer/lexer.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   lexer.h                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: shattori <shattori@student.42.fr>          +#+  +:+       +#+        */
+/*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/22 18:51:48 by shattori          #+#    #+#             */
-/*   Updated: 2025/06/29 16:08:03 by shattori         ###   ########.fr       */
+/*   Updated: 2025/07/04 20:41:06 by nando            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -80,6 +80,8 @@ typedef struct s_lexer
 	size_t			move;
 	t_statetype		state;
 	t_statetype		prev_state;
+	int				left_p_count;
+	int				right_p_count;
 	int				assignment_flag;
 }					t_lexer;
 
@@ -95,6 +97,7 @@ void				append_tok_and_set_state(t_lexer *ctx, t_statetype state);
 void				append_tok_and_reset_state(t_lexer *ctx, t_tokentype type);
 void				free_tokens(t_token *head);
 void				quate_error(t_lexer *ctx);
+void				parent_error(t_lexer *ctx);
 int					ft_isspace(int c);
 int					is_valid_var_name(char *buf_word);
 void				lexer_default(t_lexer *ctx, char c);
@@ -107,6 +110,5 @@ void				run_lexer(t_lexer *ctx);
 t_token				*finish_lexing(t_lexer *ctx);
 t_token				*lexer(char *input);
 void				lexer_word2(t_lexer *ctx, char c);
-
 
 #endif

--- a/lexer/token.c
+++ b/lexer/token.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   token.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: shattori <shattori@student.42.fr>          +#+  +:+       +#+        */
+/*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/29 17:16:10 by nando             #+#    #+#             */
-/*   Updated: 2025/06/22 18:53:52 by shattori         ###   ########.fr       */
+/*   Updated: 2025/07/04 20:39:27 by nando            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,7 @@ t_token	*create_token(t_tokentype type, char *word)
 {
 	t_token	*tok;
 
-	tok = malloc(sizeof * tok);
+	tok = malloc(sizeof *tok);
 	if (!tok)
 		return (NULL);
 	tok->type = type;
@@ -52,6 +52,10 @@ void	append_tok_and_reset_state(t_lexer *ctx, t_tokentype type)
 	ctx->state = STA_DEFAULT;
 	if (type == TOK_HEREDOC || type == TOK_REDIR_APP || type == TOK_OR)
 		ctx->move = 2;
+	if (type == TOK_LPAREN)
+		ctx->left_p_count++;
+	if (type == TOK_RPAREN)
+		ctx->right_p_count++;
 }
 
 void	free_tokens(t_token *head)

--- a/lexer/utils.c
+++ b/lexer/utils.c
@@ -6,11 +6,18 @@
 /*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/29 17:18:47 by nando             #+#    #+#             */
-/*   Updated: 2025/07/02 15:15:47 by nando            ###   ########.fr       */
+/*   Updated: 2025/07/04 20:40:20 by nando            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "lexer.h"
+
+void	parent_error(t_lexer *ctx)
+{
+	ft_printf("parent not closed.\n");
+	free_buf(&ctx->buf);
+	free_tokens(ctx->head);
+}
 
 void	quate_error(t_lexer *ctx)
 {


### PR DESCRIPTION
() subshellの戸締りが上手く行っていない時のエラーハンドリングを実装

"nando@LAPTOP-CFDLBI5U:~/42cursus/level3/minishell-proto$ ./minishell 
/home/nando/42cursus/level3/minishell-proto $ cat << "E
quate not closed.
/home/nando/42cursus/level3/minishell-proto $ (cat << E | ls
parent not closed.
/home/nando/42cursus/level3/minishell-proto $ cat << E ) | ls
parent not closed.
/home/nando/42cursus/level3/minishell-proto $ cat << E"
quate not closed.
/home/nando/42cursus/level3/minishell-proto $ 
exit"