### PR TITLE
fix/redir-in-quote

### DIFF
--- a/expander/expander.c
+++ b/expander/expander.c
@@ -6,7 +6,7 @@
 /*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/08 14:30:21 by nando             #+#    #+#             */
-/*   Updated: 2025/07/11 17:00:35 by nando            ###   ########.fr       */
+/*   Updated: 2025/07/12 14:49:28 by nando            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -104,7 +104,7 @@ void	expander(t_andor *ast, t_shell *shell)
 		{
 			redirs = (t_redirection*)redir_list->content;
 			if(redirs->filename  != NULL)
-				redirs->filename = remove_quote(redirs->filename);
+				redirs->filename = remove_all_quote(redirs->filename);
 			redir_list = redir_list->next;
 		}
 		if (cmd->argv && cmd->argv[0])

--- a/expander/expander.h
+++ b/expander/expander.h
@@ -6,7 +6,7 @@
 /*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/26 20:20:02 by nando             #+#    #+#             */
-/*   Updated: 2025/07/11 16:59:51 by nando            ###   ########.fr       */
+/*   Updated: 2025/07/12 14:49:46 by nando            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -85,7 +85,7 @@ char						*make_new_arg(char *arg, t_var *var);
 char						*expand_variables(char *arg, t_shell *shell);
 char						*expand_tilda(char *arg, t_env *env);
 char						*remove_quote(char *arg);
-char						*remove_all_quotes(char *arg);
+char						*remove_all_quote(char *arg);
 char						*expand_all_type(char *arg, t_shell *shell,
 								t_expand *ctx);
 void						expander(t_andor *ast, t_shell *shell);

--- a/expander/utils4.c
+++ b/expander/utils4.c
@@ -6,7 +6,7 @@
 /*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/10 23:28:24 by nando             #+#    #+#             */
-/*   Updated: 2025/07/12 12:56:34 by nando            ###   ########.fr       */
+/*   Updated: 2025/07/12 14:49:19 by nando            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,33 +30,37 @@ char	*remove_quote(char *arg)
 	return (ft_strdup(arg));
 }
 
-char	*remove_all_quotes(char *arg)
+char	*remove_all_quote(char *arg)
 {
-	size_t	len;
-	int		i;
-	int		quote_count;
 	char	*res;
-	char	*tmp;
+	size_t	len;
+	size_t	i;
+	size_t	count;
 
-	len = ft_strlen(arg);
-	if (len < 2)
-		return (ft_strdup(arg));
 	i = 0;
-	quote_count = 0;
-	tmp = NULL;
-	while (arg[i])
+	count = 0;
+	len = ft_strlen(arg);
+	while (i < len)
 	{
-		if (arg[i] == '\"' || arg[i] == '\'')
-		{
-			tmp = ft_strjoin(tmp, &arg[i + 1]);
-			i = i + 2;
-		}
-		else
-			tmp = ft_strjoin(tmp, &arg[i]);
+		if (arg[i] != '\'' && arg[i] != '\"')
+			count++;
+		i++;
 	}
-	free(arg);
-	arg = tmp;
-	return (ft_strdup(arg));
+	res = malloc(sizeof(char) * (count + 1));
+	memset(res, 0, count + 1);
+	i = 0;
+	count = 0;
+	while (i < len)
+	{
+		if (arg[i] != '\'' && arg[i] != '\"')
+		{
+			res[count] = arg[i];
+			count++;
+		}
+		i++;
+	}
+	res[count] = '\0';
+	return (res);
 }
 
 char	*expand_all_type(char *arg, t_shell *shell, t_expand *ctx)


### PR DESCRIPTION
Test  87: ✅ ls >"./outfiles/outfile""1""2""3""4""5" 

上記のようなredir->filenameの中にクォートが入り込んでる場合にもすべて削除する関数を実装しました。